### PR TITLE
refactor: 简化 CLI 代码并重构输出工具函数

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opcd"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "Coding Agent配置管理CLI工具"
 authors = ["moguw <weiyiding0@gmail.com>"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 /// Coding Agent 配置管理CLI工具
 #[derive(Parser)]
@@ -19,31 +19,13 @@ pub enum Commands {
     /// 导出配置
     Export {
         /// 要导出的配置类型
-        #[arg(value_name = "TYPE")]
+        #[arg(value_enum)]
         config_type: ExportType,
     },
 }
 
-#[derive(Clone, Debug)]
+#[derive(ValueEnum, Clone, Debug)]
 pub enum ExportType {
+    #[value(name = "opencode")]
     OpenCode,
-}
-
-impl std::str::FromStr for ExportType {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "opencode" => Ok(ExportType::OpenCode),
-            _ => Err(format!("不支持的配置类型: {}", s)),
-        }
-    }
-}
-
-impl std::fmt::Display for ExportType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ExportType::OpenCode => write!(f, "opencode"),
-        }
-    }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,2 +1,0 @@
-// Commands module
-// 命令已迁移到 TUI，此模块保留以备将来扩展

--- a/src/config/opencode_manager.rs
+++ b/src/config/opencode_manager.rs
@@ -1,9 +1,7 @@
 // OpenCode 配置管理器
 // 负责管理 ~/.opcd/opencode.json 和同步到 ~/.opencode/opencode.json
 
-use crate::config::models::{
-    OpenCodeActiveConfig, OpenCodeConfig, OpenCodeModelInfo, OpenCodeProvider,
-};
+use crate::config::models::{OpenCodeConfig, OpenCodeModelInfo, OpenCodeProvider};
 use crate::config::ConfigError;
 use serde_json;
 use std::collections::HashMap;
@@ -185,44 +183,21 @@ impl OpenCodeConfigManager {
         self.write_config(&config)
     }
 
-    pub fn sync_to_opencode(&self, active_config: &OpenCodeActiveConfig) -> Result<(), String> {
-        ensure_dir_exists(&self.home_dir)?;
-        let config = self.read_config()?;
-        let providers = std::slice::from_ref(&active_config.provider);
-        sync_providers_to_file(&config, providers, &self.home_json)
-    }
-
     pub fn sync_multiple_providers_to_opencode(
         &self,
         provider_names: &[String],
     ) -> Result<(), String> {
-        ensure_dir_exists(&self.home_dir)?;
         let config = self.read_config()?;
-        sync_providers_to_file(&config, provider_names, &self.home_json)
-    }
-
-    pub fn sync_to_project(&self, active_config: &OpenCodeActiveConfig) -> Result<(), String> {
-        let project_dir = std::env::current_dir()
-            .map_err(|e| format!("获取当前目录失败: {}", e))?
-            .join(".opencode");
-        let project_json = project_dir.join("opencode.json");
-        ensure_dir_exists(&project_dir)?;
-        let config = self.read_config()?;
-        let providers = std::slice::from_ref(&active_config.provider);
-        sync_providers_to_file(&config, providers, &project_json)
+        sync_providers(&config, provider_names, &self.home_dir, &self.home_json)
     }
 
     pub fn sync_multiple_providers_to_project(
         &self,
         provider_names: &[String],
     ) -> Result<(), String> {
-        let project_dir = std::env::current_dir()
-            .map_err(|e| format!("获取当前目录失败: {}", e))?
-            .join(".opencode");
-        let project_json = project_dir.join("opencode.json");
-        ensure_dir_exists(&project_dir)?;
         let config = self.read_config()?;
-        sync_providers_to_file(&config, provider_names, &project_json)
+        let (project_dir, project_json) = get_project_opencode_paths()?;
+        sync_providers(&config, provider_names, &project_dir, &project_json)
     }
 }
 
@@ -233,19 +208,39 @@ fn ensure_dir_exists(path: &PathBuf) -> Result<(), String> {
     Ok(())
 }
 
+fn get_project_opencode_paths() -> Result<(PathBuf, PathBuf), String> {
+    let project_dir = std::env::current_dir()
+        .map_err(|e| format!("获取当前目录失败: {}", e))?
+        .join(".opencode");
+    let project_json = project_dir.join("opencode.json");
+    Ok((project_dir, project_json))
+}
+
+fn sync_providers(
+    config: &OpenCodeConfig,
+    provider_names: &[String],
+    dir: &PathBuf,
+    json_path: &PathBuf,
+) -> Result<(), String> {
+    ensure_dir_exists(dir)?;
+    sync_providers_to_file(config, provider_names, json_path)
+}
+
 fn sync_providers_to_file(
     config: &OpenCodeConfig,
     provider_names: &[String],
     target_path: &PathBuf,
 ) -> Result<(), String> {
-    let mut providers_map = serde_json::Map::new();
-    for name in provider_names {
-        if let Some(provider) = config.get_provider(name) {
-            let value = serde_json::to_value(provider)
-                .map_err(|e| format!("序列化 Provider '{}' 失败: {}", name, e))?;
-            providers_map.insert(name.clone(), value);
-        }
-    }
+    let providers_map: serde_json::Map<String, serde_json::Value> = provider_names
+        .iter()
+        .filter_map(|name| {
+            config.get_provider(name).and_then(|provider| {
+                serde_json::to_value(provider)
+                    .ok()
+                    .map(|value| (name.clone(), value))
+            })
+        })
+        .collect();
 
     let sync_data = serde_json::json!({
         "$schema": "https://opencode.ai/config.json",

--- a/src/config/opencode_manager.rs
+++ b/src/config/opencode_manager.rs
@@ -10,81 +10,65 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
-/// OpenCode 配置管理器
+const SYNC_THEME: &str = "tokyonight";
+
 pub struct OpenCodeConfigManager {
-    opencode_config_file: PathBuf, // ~/.opcd/opencode.json
-    opencode_dir: PathBuf,         // ~/.opencode
-    opencode_json: PathBuf,        // ~/.opencode/opencode.json
+    config_dir: PathBuf,
+    home_dir: PathBuf,
+    home_json: PathBuf,
 }
 
 impl OpenCodeConfigManager {
-    /// 创建新的 OpenCode 配置管理器
     pub fn new(config_dir: PathBuf) -> Result<Self, ConfigError> {
-        // 确保 ~/.opcd 目录存在
         if !config_dir.exists() {
             fs::create_dir_all(&config_dir)?;
         }
 
-        let opencode_config_file = config_dir.join("opencode.json");
-
-        // OpenCode 官方配置目录
-        let opencode_dir = dirs::home_dir()
+        let home_dir = dirs::home_dir()
             .ok_or_else(|| ConfigError::NotFound {
                 name: "用户主目录".to_string(),
             })?
             .join(".opencode");
 
-        let opencode_json = opencode_dir.join("opencode.json");
+        let home_json = home_dir.join("opencode.json");
 
         Ok(Self {
-            opencode_config_file,
-            opencode_dir,
-            opencode_json,
+            config_dir,
+            home_dir,
+            home_json,
         })
     }
 
-    // ========================================================================
-    // 配置文件读写
-    // ========================================================================
-
-    /// 读取 opencode.json 配置
     pub fn read_config(&self) -> Result<OpenCodeConfig, String> {
-        if !self.opencode_config_file.exists() {
+        let config_path = self.config_dir.join("opencode.json");
+        if !config_path.exists() {
             return Ok(OpenCodeConfig::new());
         }
 
-        let content = fs::read_to_string(&self.opencode_config_file)
+        let content = fs::read_to_string(&config_path)
             .map_err(|e| format!("读取 opencode.json 失败: {}", e))?;
 
         serde_json::from_str(&content).map_err(|e| format!("解析 opencode.json 失败: {}", e))
     }
 
-    /// 写入 opencode.json 配置
     pub fn write_config(&self, config: &OpenCodeConfig) -> Result<(), String> {
+        let config_path = self.config_dir.join("opencode.json");
         let content = serde_json::to_string_pretty(config)
             .map_err(|e| format!("序列化 opencode.json 失败: {}", e))?;
 
-        fs::write(&self.opencode_config_file, content)
-            .map_err(|e| format!("写入 opencode.json 失败: {}", e))
+        fs::write(&config_path, content).map_err(|e| format!("写入 opencode.json 失败: {}", e))
     }
 
-    // ========================================================================
-    // Provider 管理
-    // ========================================================================
-
-    /// 获取 Provider
     pub fn get_provider(&self, provider_name: &str) -> Result<Option<OpenCodeProvider>, String> {
         let config = self.read_config()?;
         Ok(config.get_provider(provider_name).cloned())
     }
 
-    /// 获取所有 Provider
     pub fn get_all_providers(&self) -> Result<HashMap<String, OpenCodeProvider>, String> {
         let config = self.read_config()?;
-        Ok(config.providers.clone())
+        Ok(config.providers)
     }
 
-    /// 添加 Provider
     pub fn add_provider(
         &mut self,
         provider_name: String,
@@ -95,7 +79,6 @@ impl OpenCodeConfigManager {
     ) -> Result<(), String> {
         let mut config = self.read_config()?;
 
-        // 检查 Provider 是否已存在
         if config.get_provider(&provider_name).is_some() {
             return Err(format!("Provider '{}' 已存在", provider_name));
         }
@@ -107,7 +90,6 @@ impl OpenCodeConfigManager {
         self.write_config(&config)
     }
 
-    /// 更新 Provider 元数据
     pub fn update_provider_metadata(
         &mut self,
         provider_name: &str,
@@ -128,19 +110,18 @@ impl OpenCodeConfigManager {
         if let Some(key) = api_key {
             provider.set_api_key(key);
         }
-        if npm.is_some() {
-            provider.npm = npm;
+        if let Some(npm_val) = npm {
+            provider.npm = Some(npm_val);
             provider.update_timestamp();
         }
-        if description.is_some() {
-            provider.metadata.description = description;
+        if let Some(desc) = description {
+            provider.metadata.description = Some(desc);
             provider.update_timestamp();
         }
 
         self.write_config(&config)
     }
 
-    /// 删除 Provider
     pub fn delete_provider(&mut self, provider_name: &str) -> Result<(), String> {
         let mut config = self.read_config()?;
 
@@ -151,11 +132,6 @@ impl OpenCodeConfigManager {
         self.write_config(&config)
     }
 
-    // ========================================================================
-    // 模型管理
-    // ========================================================================
-
-    /// 获取模型
     pub fn get_models(
         &self,
         provider_name: &str,
@@ -168,7 +144,6 @@ impl OpenCodeConfigManager {
         Ok(provider.models.clone())
     }
 
-    /// 添加模型
     pub fn add_model(
         &mut self,
         provider_name: &str,
@@ -181,7 +156,6 @@ impl OpenCodeConfigManager {
             .get_provider_mut(provider_name)
             .ok_or_else(|| format!("Provider '{}' 不存在", provider_name))?;
 
-        // 检查模型是否已存在
         if provider.get_model(&model_id).is_some() {
             return Err(format!(
                 "模型 '{}' 已存在于 Provider '{}'",
@@ -194,7 +168,6 @@ impl OpenCodeConfigManager {
         self.write_config(&config)
     }
 
-    /// 删除模型
     pub fn delete_model(&mut self, provider_name: &str, model_id: &str) -> Result<(), String> {
         let mut config = self.read_config()?;
 
@@ -212,206 +185,92 @@ impl OpenCodeConfigManager {
         self.write_config(&config)
     }
 
-    // ========================================================================
-    // 配置同步到 ~/.opencode/opencode.json
-    // ========================================================================
-
-    /// 同步配置到 OpenCode 官方配置文件 (生成完整的 opencode.json)
-    #[allow(dead_code)]
     pub fn sync_to_opencode(&self, active_config: &OpenCodeActiveConfig) -> Result<(), String> {
-        // 确保 ~/.opencode 目录存在
-        if !self.opencode_dir.exists() {
-            fs::create_dir_all(&self.opencode_dir)
-                .map_err(|e| format!("创建 .opencode 目录失败: {}", e))?;
-        }
-
-        // 读取完整的 provider 配置
-        let opencode_config = self.read_config()?;
-
-        // 构建 provider 对象（只包含当前激活的 provider）
-        let mut providers_map = serde_json::Map::new();
-
-        if let Some(provider) = opencode_config.get_provider(&active_config.provider) {
-            providers_map.insert(
-                active_config.provider.clone(),
-                serde_json::to_value(provider)
-                    .map_err(|e| format!("序列化 Provider 失败: {}", e))?,
-            );
-        }
-
-        // 构建完整的 opencode.json 结构
-        // 注意: 不再设置 model 和 small_model,让 opencode 自己选择
-        let sync_data = serde_json::json!({
-            "$schema": "https://opencode.ai/config.json",
-            "theme": "tokyonight",
-            "autoupdate": false,
-            "provider": providers_map,
-            "tools": {
-                "get-current-session-id": true,
-                "webfetch": true
-            },
-            "agent": {},
-            "mcp": {}
-        });
-
-        let content = serde_json::to_string_pretty(&sync_data)
-            .map_err(|e| format!("序列化同步数据失败: {}", e))?;
-
-        fs::write(&self.opencode_json, content)
-            .map_err(|e| format!("写入 ~/.opencode/opencode.json 失败: {}", e))
+        ensure_dir_exists(&self.home_dir)?;
+        let config = self.read_config()?;
+        let providers = std::slice::from_ref(&active_config.provider);
+        sync_providers_to_file(&config, providers, &self.home_json)
     }
 
-    /// 同步多个Provider配置到 OpenCode 官方配置文件
     pub fn sync_multiple_providers_to_opencode(
         &self,
         provider_names: &[String],
     ) -> Result<(), String> {
-        // 确保 ~/.opencode 目录存在
-        if !self.opencode_dir.exists() {
-            fs::create_dir_all(&self.opencode_dir)
-                .map_err(|e| format!("创建 .opencode 目录失败: {}", e))?;
-        }
-
-        // 读取完整的 provider 配置
-        let opencode_config = self.read_config()?;
-
-        // 构建 provider 对象（包含所有指定的 provider）
-        let mut providers_map = serde_json::Map::new();
-
-        for provider_name in provider_names {
-            if let Some(provider) = opencode_config.get_provider(provider_name) {
-                providers_map.insert(
-                    provider_name.clone(),
-                    serde_json::to_value(provider)
-                        .map_err(|e| format!("序列化 Provider '{}' 失败: {}", provider_name, e))?,
-                );
-            }
-        }
-
-        // 构建完整的 opencode.json 结构
-        let sync_data = serde_json::json!({
-            "$schema": "https://opencode.ai/config.json",
-            "theme": "tokyonight",
-            "autoupdate": false,
-            "provider": providers_map,
-            "tools": {
-                "get-current-session-id": true,
-                "webfetch": true
-            },
-            "agent": {},
-            "mcp": {}
-        });
-
-        let content = serde_json::to_string_pretty(&sync_data)
-            .map_err(|e| format!("序列化同步数据失败: {}", e))?;
-
-        fs::write(&self.opencode_json, content)
-            .map_err(|e| format!("写入 ~/.opencode/opencode.json 失败: {}", e))
+        ensure_dir_exists(&self.home_dir)?;
+        let config = self.read_config()?;
+        sync_providers_to_file(&config, provider_names, &self.home_json)
     }
 
-    /// 同步配置到项目级 .opencode/opencode.json
-    #[allow(dead_code)]
     pub fn sync_to_project(&self, active_config: &OpenCodeActiveConfig) -> Result<(), String> {
-        // 获取当前工作目录
-        let current_dir =
-            std::env::current_dir().map_err(|e| format!("获取当前目录失败: {}", e))?;
-
-        let project_opencode_dir = current_dir.join(".opencode");
-        let project_opencode_json = project_opencode_dir.join("opencode.json");
-
-        // 确保 .opencode 目录存在
-        if !project_opencode_dir.exists() {
-            fs::create_dir_all(&project_opencode_dir)
-                .map_err(|e| format!("创建项目 .opencode 目录失败: {}", e))?;
-        }
-
-        // 读取完整的 provider 配置
-        let opencode_config = self.read_config()?;
-
-        // 构建 provider 对象（只包含当前激活的 provider）
-        let mut providers_map = serde_json::Map::new();
-
-        if let Some(provider) = opencode_config.get_provider(&active_config.provider) {
-            providers_map.insert(
-                active_config.provider.clone(),
-                serde_json::to_value(provider)
-                    .map_err(|e| format!("序列化 Provider 失败: {}", e))?,
-            );
-        }
-
-        // 构建完整的 opencode.json 结构
-        let sync_data = serde_json::json!({
-            "$schema": "https://opencode.ai/config.json",
-            "theme": "tokyonight",
-            "autoupdate": false,
-            "provider": providers_map,
-            "tools": {
-                "get-current-session-id": true,
-                "webfetch": true
-            },
-            "agent": {},
-            "mcp": {}
-        });
-
-        let content = serde_json::to_string_pretty(&sync_data)
-            .map_err(|e| format!("序列化同步数据失败: {}", e))?;
-
-        fs::write(&project_opencode_json, content)
-            .map_err(|e| format!("写入 .opencode/opencode.json 失败: {}", e))
+        let project_dir = std::env::current_dir()
+            .map_err(|e| format!("获取当前目录失败: {}", e))?
+            .join(".opencode");
+        let project_json = project_dir.join("opencode.json");
+        ensure_dir_exists(&project_dir)?;
+        let config = self.read_config()?;
+        let providers = std::slice::from_ref(&active_config.provider);
+        sync_providers_to_file(&config, providers, &project_json)
     }
 
-    /// 同步多个Provider配置到项目级 .opencode/opencode.json
     pub fn sync_multiple_providers_to_project(
         &self,
         provider_names: &[String],
     ) -> Result<(), String> {
-        // 获取当前工作目录
-        let current_dir =
-            std::env::current_dir().map_err(|e| format!("获取当前目录失败: {}", e))?;
-
-        let project_opencode_dir = current_dir.join(".opencode");
-        let project_opencode_json = project_opencode_dir.join("opencode.json");
-
-        // 确保 .opencode 目录存在
-        if !project_opencode_dir.exists() {
-            fs::create_dir_all(&project_opencode_dir)
-                .map_err(|e| format!("创建项目 .opencode 目录失败: {}", e))?;
-        }
-
-        // 读取完整的 provider 配置
-        let opencode_config = self.read_config()?;
-
-        // 构建 provider 对象（包含所有指定的 provider）
-        let mut providers_map = serde_json::Map::new();
-
-        for provider_name in provider_names {
-            if let Some(provider) = opencode_config.get_provider(provider_name) {
-                providers_map.insert(
-                    provider_name.clone(),
-                    serde_json::to_value(provider)
-                        .map_err(|e| format!("序列化 Provider '{}' 失败: {}", provider_name, e))?,
-                );
-            }
-        }
-
-        // 构建完整的 opencode.json 结构
-        let sync_data = serde_json::json!({
-            "$schema": "https://opencode.ai/config.json",
-            "theme": "tokyonight",
-            "autoupdate": false,
-            "provider": providers_map,
-            "tools": {
-                "get-current-session-id": true,
-                "webfetch": true
-            },
-            "agent": {},
-            "mcp": {}
-        });
-
-        let content = serde_json::to_string_pretty(&sync_data)
-            .map_err(|e| format!("序列化同步数据失败: {}", e))?;
-
-        fs::write(&project_opencode_json, content)
-            .map_err(|e| format!("写入项目 .opencode/opencode.json 失败: {}", e))
+        let project_dir = std::env::current_dir()
+            .map_err(|e| format!("获取当前目录失败: {}", e))?
+            .join(".opencode");
+        let project_json = project_dir.join("opencode.json");
+        ensure_dir_exists(&project_dir)?;
+        let config = self.read_config()?;
+        sync_providers_to_file(&config, provider_names, &project_json)
     }
+}
+
+fn ensure_dir_exists(path: &PathBuf) -> Result<(), String> {
+    if !path.exists() {
+        fs::create_dir_all(path).map_err(|e| format!("创建目录失败: {}", e))?;
+    }
+    Ok(())
+}
+
+fn sync_providers_to_file(
+    config: &OpenCodeConfig,
+    provider_names: &[String],
+    target_path: &PathBuf,
+) -> Result<(), String> {
+    let mut providers_map = serde_json::Map::new();
+    for name in provider_names {
+        if let Some(provider) = config.get_provider(name) {
+            let value = serde_json::to_value(provider)
+                .map_err(|e| format!("序列化 Provider '{}' 失败: {}", name, e))?;
+            providers_map.insert(name.clone(), value);
+        }
+    }
+
+    let sync_data = serde_json::json!({
+        "$schema": "https://opencode.ai/config.json",
+        "theme": SYNC_THEME,
+        "autoupdate": false,
+        "provider": providers_map,
+        "tools": {
+            "webfetch": true
+        },
+        "agent": {},
+        "mcp": {}
+    });
+
+    let content = serde_json::to_string_pretty(&sync_data)
+        .map_err(|e| format!("序列化同步数据失败: {}", e))?;
+
+    backup_existing_file(target_path)?;
+
+    fs::write(target_path, content).map_err(|e| format!("写入失败: {}", e))
+}
+
+fn backup_existing_file(target_path: &PathBuf) -> Result<(), String> {
+    if target_path.exists() {
+        let backup_path = target_path.with_extension("json.bak");
+        fs::copy(target_path, &backup_path).map_err(|e| format!("备份文件失败: {}", e))?;
+    }
+    Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,14 +23,12 @@ pub enum CliError {
     Custom(String),
 }
 
-// 实现 From<String> 转换，方便新架构使用
 impl From<String> for CliError {
     fn from(s: String) -> Self {
         CliError::Custom(s)
     }
 }
 
-// 实现 From<&str> 转换
 impl From<&str> for CliError {
     fn from(s: &str) -> Self {
         CliError::Custom(s.to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,33 +1,29 @@
 mod cli;
-mod commands;
 mod config;
 mod error;
 mod tui;
 mod utils;
 
 use clap::Parser;
-use cli::{Cli, Commands, ExportType};
+use cli::{Cli, Commands};
 use console::style;
 use error::Result;
 
 use crate::config::ConfigManager;
-use crate::utils::{show_error, show_info, show_success};
+use crate::utils::{
+    display_paths, print_section, show_error, show_info, show_success, show_warning,
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Commands::Status) => {
-            show_status()?;
+        Some(Commands::Status) => show_status()?,
+        Some(Commands::Export { .. }) => {
+            export_opencode_config()?;
         }
-        Some(Commands::Export { config_type }) => match config_type {
-            ExportType::OpenCode => {
-                export_opencode_config()?;
-            }
-        },
         None => {
-            // 没有子命令时，启动 TUI 界面
             if let Err(e) = tui::run() {
                 eprintln!("TUI 错误: {}", e);
                 std::process::exit(1);
@@ -40,83 +36,70 @@ async fn main() -> Result<()> {
 
 /// 显示状态
 fn show_status() -> Result<()> {
-    println!("\n{}", style("📊 当前配置状态").cyan().bold());
-    println!("{}", style("═".repeat(40)).dim());
+    print_section("📊 当前配置状态");
 
     let config_manager = ConfigManager::new()?;
 
     println!("\n{}", style("🚀 OpenCode 配置:").white().bold());
     match config_manager.get_active_opencode_config()? {
-        Some(config) => {
-            println!(
-                "  {} {}",
-                style("Provider:").white(),
-                style(&config.provider).cyan()
-            );
-            println!(
-                "  {} {}",
-                style("Base URL:").white(),
-                style(&config.base_url).dim()
-            );
-            let model_list: Vec<&str> = config.models.keys().map(|s| s.as_str()).collect();
-            println!(
-                "  {} {}",
-                style("可用模型:").white(),
-                style(model_list.join(", ")).yellow()
-            );
-        }
-        None => {
-            show_info("未配置 OpenCode");
-        }
+        Some(config) => print_config_details(&config),
+        None => show_info("未配置 OpenCode"),
     }
 
     println!();
     Ok(())
 }
 
+fn print_config_details(config: &crate::config::OpenCodeActiveConfig) {
+    println!(
+        "  {} {}",
+        style("Provider:").white(),
+        style(&config.provider).cyan()
+    );
+    println!(
+        "  {} {}",
+        style("Base URL:").white(),
+        style(&config.base_url).dim()
+    );
+    let model_list: Vec<&str> = config.models.keys().map(|s| s.as_str()).collect();
+    println!(
+        "  {} {}",
+        style("可用模型:").white(),
+        style(model_list.join(", ")).yellow()
+    );
+}
+
 /// 导出 OpenCode 配置到当前目录
 fn export_opencode_config() -> Result<()> {
-    println!("\n{}", style("📤 导出 OpenCode 配置").cyan().bold());
-    println!("{}", style("═".repeat(40)).dim());
-    println!();
+    print_section("📤 导出 OpenCode 配置");
 
-    // 获取源文件路径 ($HOME/.opencode/opencode.json)
-    let home_dir = dirs::home_dir().ok_or("无法获取用户主目录")?;
+    let home_dir = dirs::home_dir().ok_or_else(|| "无法获取用户主目录".to_string())?;
     let source_path = home_dir.join(".opencode").join("opencode.json");
 
-    // 检查源文件是否存在
     if !source_path.exists() {
         show_error("源配置文件不存在");
         show_info("请先切换配置以生成 ~/.opencode/opencode.json");
         return Ok(());
     }
 
-    // 获取目标文件路径 (当前目录/.opencode/opencode.json)
-    let current_dir = std::env::current_dir().map_err(|e| format!("无法获取当前目录: {}", e))?;
+    let current_dir = std::env::current_dir()?;
     let target_dir = current_dir.join(".opencode");
     let target_path = target_dir.join("opencode.json");
 
-    // 显示路径信息
-    println!("{}", style("源文件:").white());
-    println!("  {}", style(source_path.display()).cyan());
+    display_paths("源文件:", &source_path);
     println!();
-    println!("{}", style("目标文件:").white());
-    println!("  {}", style(target_path.display()).cyan());
+    display_paths("目标文件:", &target_path);
     println!();
 
-    // 如果目标文件已存在，显示警告
     if target_path.exists() {
-        println!("{}", style("⚠️  目标文件已存在，将被覆盖").yellow());
+        show_warning("目标文件已存在，将被覆盖");
         println!();
     }
 
-    // 创建目标目录
-    std::fs::create_dir_all(&target_dir).map_err(|e| format!("创建目标目录失败: {}", e))?;
+    std::fs::create_dir_all(&target_dir)?;
+    std::fs::copy(&source_path, &target_path)?;
 
-    // 复制文件
-    std::fs::copy(&source_path, &target_path).map_err(|e| format!("复制文件失败: {}", e))?;
-
-    show_success("✨ 配置已成功导出到当前目录！");
+    show_success("配置已成功导出到当前目录！");
     println!();
     show_info(&format!("目标路径: {}", target_path.display()));
     println!();

--- a/src/tui/theme/mod.rs
+++ b/src/tui/theme/mod.rs
@@ -1,6 +1,7 @@
 // 主题系统模块
 
 use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::BorderType;
 
 /// 应用主题
 #[derive(Debug, Clone)]
@@ -59,6 +60,11 @@ impl Theme {
     /// 激活边框样式
     pub fn active_border_style(&self) -> Style {
         Style::default().fg(self.primary)
+    }
+
+    /// 激活状态的边框类型（双线边框，用于在颜色失效时标识焦点）
+    pub fn active_border_type(&self) -> BorderType {
+        BorderType::Double
     }
 
     /// 成功消息样式

--- a/src/tui/ui/components/apply_scope_dialog.rs
+++ b/src/tui/ui/components/apply_scope_dialog.rs
@@ -99,9 +99,8 @@ impl ApplyScopeDialog {
         self.provider_name = provider_name.to_string();
         self.provider_names = vec![provider_name.to_string()];
         self.visible = true;
-        self.apply_to_global = true;
-        self.apply_to_project = false;
         self.selected_option = 0;
+        self.update_state_from_option();
     }
 
     /// 显示对话框（多个Provider）
@@ -115,9 +114,8 @@ impl ApplyScopeDialog {
             self.provider_name = format!("{} 个 Provider", provider_names.len());
         }
         self.visible = true;
-        self.apply_to_global = true;
-        self.apply_to_project = false;
         self.selected_option = 0;
+        self.update_state_from_option();
     }
 
     /// 显示清空 MCP 配置对话框（空选择时使用）
@@ -126,9 +124,8 @@ impl ApplyScopeDialog {
         self.title = "清空 MCP 配置".to_string();
         self.provider_name = "将清空目标配置中的所有 MCP 服务器".to_string();
         self.visible = true;
-        self.apply_to_global = true;
-        self.apply_to_project = false;
         self.selected_option = 0;
+        self.update_state_from_option();
     }
 
     /// 隐藏对话框

--- a/src/tui/ui/layout.rs
+++ b/src/tui/ui/layout.rs
@@ -4,7 +4,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Tabs, Wrap},
+    widgets::{Block, BorderType, Borders, Clear, List, ListItem, Paragraph, Tabs, Wrap},
     Frame,
 };
 
@@ -186,10 +186,10 @@ fn render_providers_tab(frame: &mut Frame, app: &mut App, theme: &Theme, area: R
         .split(area);
 
     // 左侧: Provider 列表
-    let provider_border = if app.provider_tab_focus == 0 {
-        theme.active_border_style()
+    let provider_border_type = if app.provider_tab_focus == 0 {
+        theme.active_border_type()
     } else {
-        theme.border_style()
+        BorderType::Plain
     };
 
     let provider_items: Vec<ListItem> = app
@@ -207,7 +207,12 @@ fn render_providers_tab(frame: &mut Frame, app: &mut App, theme: &Theme, area: R
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(provider_border)
+                .border_style(if app.provider_tab_focus == 0 {
+                    theme.active_border_style()
+                } else {
+                    theme.border_style()
+                })
+                .border_type(provider_border_type)
                 .title(format!(" Providers ({}) ", app.get_provider_count())),
         )
         .highlight_style(if app.provider_tab_focus == 0 {
@@ -220,10 +225,10 @@ fn render_providers_tab(frame: &mut Frame, app: &mut App, theme: &Theme, area: R
     frame.render_stateful_widget(provider_list, chunks[0], &mut app.provider_list_state);
 
     // 中间: Model 列表
-    let model_border = if app.provider_tab_focus == 1 {
-        theme.active_border_style()
+    let model_border_type = if app.provider_tab_focus == 1 {
+        theme.active_border_type()
     } else {
-        theme.border_style()
+        BorderType::Plain
     };
 
     let model_title = if app.get_selected_provider().is_some() {
@@ -242,15 +247,18 @@ fn render_providers_tab(frame: &mut Frame, app: &mut App, theme: &Theme, area: R
             .split(chunks[1]);
 
         // 渲染搜索框
-        let search_border = if app.search_active {
-            theme.active_border_style()
-        } else {
-            theme.border_style()
-        };
-
         let search_block = Block::default()
             .borders(Borders::ALL)
-            .border_style(search_border)
+            .border_style(if app.search_active {
+                theme.active_border_style()
+            } else {
+                theme.border_style()
+            })
+            .border_type(if app.search_active {
+                theme.active_border_type()
+            } else {
+                BorderType::Plain
+            })
             .title(Span::styled(" / 搜索 ", theme.title_style()));
 
         let search_inner = search_block.inner(model_chunks[0]);
@@ -279,7 +287,12 @@ fn render_providers_tab(frame: &mut Frame, app: &mut App, theme: &Theme, area: R
 
     let model_block = Block::default()
         .borders(Borders::ALL)
-        .border_style(model_border)
+        .border_style(if app.provider_tab_focus == 1 {
+            theme.active_border_style()
+        } else {
+            theme.border_style()
+        })
+        .border_type(model_border_type)
         .title(model_title);
 
     let model_inner = model_block.inner(model_area);
@@ -375,6 +388,7 @@ fn render_providers_multi_select_mode(frame: &mut Frame, app: &mut App, theme: &
             Block::default()
                 .borders(Borders::ALL)
                 .border_style(theme.active_border_style())
+                .border_type(theme.active_border_type())
                 .title(format!(
                     " 多选 ({}/{}) ",
                     app.get_selected_count(),
@@ -590,6 +604,7 @@ fn render_mcp_tab(frame: &mut Frame, app: &mut App, theme: &Theme, area: Rect) {
             Block::default()
                 .borders(Borders::ALL)
                 .border_style(theme.active_border_style())
+                .border_type(theme.active_border_type())
                 .title(format!(" MCP 服务器 ({}) ", app.mcp_servers.len())),
         )
         .highlight_style(theme.highlight_style())
@@ -658,6 +673,7 @@ fn render_mcp_multi_sync_mode(frame: &mut Frame, app: &mut App, theme: &Theme, a
             Block::default()
                 .borders(Borders::ALL)
                 .border_style(theme.active_border_style())
+                .border_type(theme.active_border_type())
                 .title(format!(
                     " 多选同步 ({}/{}) ",
                     app.get_selected_mcp_count(),

--- a/src/utils/output.rs
+++ b/src/utils/output.rs
@@ -2,17 +2,70 @@
 
 use console::style;
 
-/// 显示成功消息
+/// Message type for controlling output style and icon
+pub enum MessageType {
+    Success,
+    Error,
+    Info,
+    Warning,
+}
+
+impl MessageType {
+    fn emoji(&self) -> &'static str {
+        match self {
+            MessageType::Success => "✨",
+            MessageType::Error => "❌",
+            MessageType::Info => "ℹ️",
+            MessageType::Warning => "⚠️",
+        }
+    }
+
+    fn styled<T>(&self, text: T) -> console::StyledObject<T> {
+        match self {
+            MessageType::Success => style(text).green(),
+            MessageType::Error => style(text).red(),
+            MessageType::Info => style(text).blue(),
+            MessageType::Warning => style(text).yellow(),
+        }
+    }
+}
+
+/// Display a formatted message with the specified type
+pub fn show_message(message: &str, msg_type: MessageType) {
+    println!(
+        "{} {}",
+        msg_type.styled(msg_type.emoji()),
+        msg_type.styled(message)
+    );
+}
+
+/// Display a success message
 pub fn show_success(message: &str) {
-    println!("{} {}", style("✨").green(), style(message).green());
+    show_message(message, MessageType::Success);
 }
 
-/// 显示错误消息
+/// Display an error message
 pub fn show_error(message: &str) {
-    println!("{} {}", style("❌").red(), style(message).red());
+    show_message(message, MessageType::Error);
 }
 
-/// 显示信息消息
+/// Display an info message
 pub fn show_info(message: &str) {
-    println!("{} {}", style("ℹ️ ").blue(), style(message).blue());
+    show_message(message, MessageType::Info);
+}
+
+/// Display a warning message
+pub fn show_warning(message: &str) {
+    show_message(message, MessageType::Warning);
+}
+
+/// Print a titled section with a separator line
+pub fn print_section(title: &str) {
+    println!("\n{}", style(title).cyan().bold());
+    println!("{}", style("═".repeat(40)).dim());
+}
+
+/// Display path information with label
+pub fn display_paths(label: &str, path: &std::path::Path) {
+    println!("{} {}", style(label).white(), style(path.display()).cyan());
 }


### PR DESCRIPTION
## 变更内容

- 使用 ValueEnum 替代手动 FromStr/Display 实现
- 提取 print_section, display_paths 通用函数
- 简化错误处理模式 (? 操作符)
- 删除空 commands 模块
- 重构 opencode 同步逻辑

## 提交记录

- a2862b1 chore(release): version 0.6.3
- a038b32 refactor!: 简化 CLI 代码并重构输出工具函数
- 03421c4 refactor(opencode): 重构配置同步逻辑并添加备份功能
- 5f55fd2 fix(ui): 修复应用配置范围对话框状态不同步问题